### PR TITLE
Color scheme background edit surface

### DIFF
--- a/lib/theme/dark_theme.dart
+++ b/lib/theme/dark_theme.dart
@@ -6,7 +6,7 @@ ThemeData darkTheme = ThemeData(
       backgroundColor: Colors.black,
     ),
     colorScheme: ColorScheme.dark(
-      background: Colors.black,
+      surface: Colors.black,
       primary: Colors.grey[900]!,
       secondary: Colors.grey[800]!,
       onPrimary: Colors.white,

--- a/lib/theme/light_theme.dart
+++ b/lib/theme/light_theme.dart
@@ -9,7 +9,7 @@ ThemeData lightTheme = ThemeData(
       titleTextStyle: TextStyle(color: Colors.black, fontSize: 20),
     ),
     colorScheme: ColorScheme.light(
-      background: Colors.grey[300]!,
+      surface: Colors.grey[300]!,
       primary: Colors.grey[200]!,
       secondary: Colors.grey[300]!,
       onPrimary: Colors.black,


### PR DESCRIPTION
- closes #5 

Fluterのversionを更新したことによるcolorSchemeのbackgroundが非推奨となったので、backgroundの代わりにsurfaceを使用しました